### PR TITLE
Update tutorials.tsx

### DIFF
--- a/src/pages/developers/tutorials.tsx
+++ b/src/pages/developers/tutorials.tsx
@@ -313,7 +313,7 @@ const TutorialPage = ({
             <ButtonLink
               leftIcon={<FaGithub />}
               variant="outline"
-              href="https://github.com/ethereum/ethereum-org-website/new/dev/src/content/developers/tutorials"
+              href="https://github.com/ethereum/ethereum-org-website/pulls"
             >
               <Translation id="page-developers-tutorials:page-tutorial-pull-request-btn" />
             </ButtonLink>


### PR DESCRIPTION
Broken link fix for bug report #14023

Fix the broken link on website in tutorials section 

## Description

Added the correct link to /tutorials.tsx to submit a pull request
href="https://github.com/ethereum/ethereum-org-website/pulls"

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
